### PR TITLE
Add pod name and base image to create cvms logs

### DIFF
--- a/src/commands/cvms/create.ts
+++ b/src/commands/cvms/create.ts
@@ -247,6 +247,8 @@ export const createCommand = new Command()
         'CVM ID': response.id,
         'Name': response.name,
         'Status': response.status,
+        'Pod Name': response.teepod.name,
+        'Base Image': response.base_image,
         'App ID': `app_${response.app_id}`,
         'App URL': response.app_url ? response.app_url : `${CLOUD_URL}/dashboard/cvms/app_${response.app_id}`,
       };


### PR DESCRIPTION
In the shade agent cli we are using the CLI to execute a command to create a cvms. Using this one command you cannot know which pod it is being deployed to thus allow you to get the deployment URL. By adding the pod name I can now create the URL string for example https://27a9031b5b3c5e792db95ffe3867be72bf4c1b6c-3000.dstack-prod8.phala.network if there is a better approach please let me know. Thanks

https://github.com/NearDeFi/shade-agent-cli/blob/modular/src/phala.js#L32